### PR TITLE
Update logging.go

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -77,7 +77,7 @@ func utcMsg(data []byte) string {
 	if UTC {
 		msg = fmt.Sprintf("[" + time.Now().UTC().String() + "] " + string(data))
 	} else {
-		msg = fmt.Sprintf("[" + time.Now().String() + "] " + string(data))
+		msg = fmt.Sprintf("[" + time.Now().Format(time.RFC3339Nano) + "] " + string(data))
 		//     msg = fmt.Sprintf("[" + time.Now().UTC().Format("2006-01-02T15:04:05.999Z") + " UTC] " + string(data))
 	}
 	return msg


### PR DESCRIPTION
Hi @vkuznet, maybe we could change the format of logging?

Because the current format with `m=+...` is a little bit difficult to catch with the logstash and I would argue that it actually decreases the readability of the logs. `RFC3339Nano` keeps the precision to the nanoseconds and automatically adds the time zone (see example here: https://go.dev/play/p/aLycNAJN7h2), so it should keep all of the functionality and make the logstash part easier.