### PR TITLE
Disable pprof and expvar before finding a way to only expose it to a …

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"runtime"
 	"time"
 
-	_ "expvar"         // to be used for monitoring, see https://github.com/divan/expvarmon
-	_ "net/http/pprof" // profiler, see https://golang.org/pkg/net/http/pprof/
+//	_ "expvar"         // to be used for monitoring, see https://github.com/divan/expvarmon
+//	_ "net/http/pprof" // profiler, see https://golang.org/pkg/net/http/pprof/
 )
 
 // gitVersion of the code shows git hash


### PR DESCRIPTION
…local port. I tried various solutions, but they did not work. The CERN Security is asking for updates, so we can disable it temporarily. After my security rota this week, I will get back to this.

Thank you!